### PR TITLE
feat: BID 2.0.0-rc1 PoC — Phases 1–4 complete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# BID 2.0.0-rc1 — Environment Variables
+# Copy this file to .env and fill in the values before running docker compose.
+
+# ── Required ──────────────────────────────────────────────────────────────────
+# HMAC secret for signing JWT tokens. Use a long random string in production.
+# Generate with: python -c "import secrets; print(secrets.token_hex(64))"
+SECRET_KEY=change-me-in-production-use-a-long-random-string
+
+# ── Optional (defaults shown) ─────────────────────────────────────────────────
+
+# SQLite database path inside the container (relative to /data volume mount).
+# Switch to postgresql+psycopg://user:pass@host:5432/bid for production.
+DATABASE_URL=sqlite:////data/bid.sqlite3
+
+# Root directory for BID project sub-folders (inside the container).
+PROJECTS_DIR=/data/projects
+
+# Maximum number of concurrent image-processing workers.
+MAX_CONCURRENT_TASKS=2
+
+# Allowed CORS origins (JSON array). Add your domain in production.
+CORS_ORIGINS=["http://localhost","http://localhost:80"]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,53 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/frontend/**'
+      - '.github/workflows/frontend.yml'
+  push:
+    branches:
+      - main
+      - 'poc/**'
+    paths:
+      - 'src/frontend/**'
+      - '.github/workflows/frontend.yml'
+
+defaults:
+  run:
+    working-directory: src/frontend
+
+jobs:
+  lint-and-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: src/frontend/dist/
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [2.0.0-rc1] — 2026-04-30 (PoC)
+
+### Summary
+
+First candidate release of the BID web migration PoC (Phases 1–4).
+Delivers a complete FastAPI backend, WebSocket real-time layer, React frontend, and
+a single-command Docker Compose stack.
+
+### Added
+
+**Phase 1 — Backend API (P1-01 … P1-06)**
+- `src/api/` — FastAPI application with OpenAPI 3.0 spec (`/docs`, `/redoc`)
+- REST endpoints: `/auth/login`, `/auth/refresh`, `/api/v1/projects`, `/api/v1/projects/{id}/settings`,
+  `/api/v1/projects/{id}/export-profiles`, `/api/v1/projects/{id}/process`,
+  `/api/v1/projects/{id}/sources`, `/api/v1/projects/{id}/exports/conflicts`,
+  `/api/v1/users`, `/health`, `/version`
+- JWT authentication (access + refresh tokens, HS256)
+- SQLite persistence via SQLAlchemy ORM (`PhotoRecord`, `AuditLog`, `User`)
+- Audit log: per-photo state and metadata change tracking
+- ≥ 80 % test coverage on the API layer
+
+**Phase 2 — WebSocket Real-Time Layer (P2-01 … P2-05)**
+- `src/api/websocket/` — FastAPI WebSocket endpoint at
+  `GET /api/v1/projects/{id}/ws?token=<JWT>`
+- `ConnectionManager`: per-project connection registry with `asyncio.Lock`
+- Message types: `state_change`, `progress`, `scan_update`, `error`, `ping`, `pong`,
+  `queue_metrics`, `server_closing`
+- Server-side heartbeat (30 s ping, 10 s pong timeout)
+- Auto-reconnect hint via `server_closing` message
+- `EventBroadcastService`: polls `bid/events/EventManager` every 5 min, broadcasts `scan_update`
+- 35 WebSocket integration tests
+
+**Phase 3 — Frontend Shell (P3-01 … P3-06)**
+- `src/frontend/` — React 18 + TypeScript + Vite project
+- React Router v6 — client-side routing with protected routes
+- Zustand stores: `authStore`, `projectStore`, `processingStore`
+- Axios API client with silent JWT refresh and request queuing
+- WebSocket client with heartbeat and auto-reconnect (`BidWebSocketClient`)
+- Layout: `AppShell`, `Header`, `Sidebar`
+- Pages: `LoginPage`, `DashboardPage`, `NotFoundPage`
+- shadcn/ui components: `Button`, `Input`, `Label`, `Card`, `Progress`, `Toast`
+- GitHub Actions CI: `.github/workflows/frontend.yml` (type-check, lint, build)
+
+**Phase 4 — Core UI Components (P4-01 … P4-06)**
+- `ProjectsPage` — list, create, delete projects; select active project (P4-01)
+- `ExportsPage` — add/edit/delete export profiles, save via PUT (P4-02)
+- `ProcessingPage` — live processing queue via WebSocket, enqueue-all button (P4-03)
+- `SourcesPage` — source tree with folder expand/collapse, photo details panel (P4-04 / P4-05)
+- `SettingsPage` — account info, FileBrowser link, dark/light/system theme toggle (P4-04 / P4-06)
+- `useToast` hook with 5 s auto-dismiss; `Toaster` component (P4-05)
+- `src/api/routers/sources.py` — new `GET /sources` and `GET /sources/{folder}/{photo}` endpoints
+
+**PoC Infrastructure (POC-01 … POC-03)**
+- `docker-compose.yml` — four-service stack: `nginx`, `api`, `frontend`, `filebrowser`
+- `nginx/nginx.conf` — reverse proxy: `/` → frontend, `/api` → backend, `/files` → FileBrowser
+- `src/Dockerfile` — multi-stage Python 3.11-slim API image
+- `src/frontend/Dockerfile` — multi-stage Node 20 + nginx frontend image
+- `.env.example` — documented environment variable template
+- `CHANGELOG.md` — this file
+
+### Changed
+
+- `src/api/main.py`: registered `sources.router` under `/api/v1`
+- `src/api/routers/` import updated to include `sources`
+- `migration_to_web_plan/implementation_plan.md`: Phases 3, 4, and PoC marked ✅ COMPLETE
+- `README.md`: added "Quick start (Docker)" section
+
+### Fixed
+
+- `src/frontend/src/lib/apiClient.ts`: `ProjectResponse`, `SourceTree`/`PhotoEntry`, `ExportProfile`,
+  `ProcessResponse` types now match actual API schemas exactly
+- `src/frontend/src/pages/ExportsPage.tsx`: rewrote to use `profiles: Record<string, ExportProfile>`
+  structure (was incorrect array-based schema)
+- `src/frontend/src/pages/SourcesPage.tsx`: rewrote to use `SourceTree.folders` tree structure
+- `src/frontend/src/pages/ProcessingPage.tsx`: updated `enqueueAll` to call correct API endpoint
+
+---
+
+## [1.x] — Desktop application (Tkinter)
+
+See git history for prior desktop-application releases.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,37 @@
 Narzędzie do automatycznego skalowania zdjęć, nakładania watermarku i eksportu do folderów delivery.  
 Tool for automatic image scaling, watermark overlay, and delivery folder export.
 
+> **BID 2.0.0-rc1** — Web PoC available. See [Quick start (Docker)](#quick-start-docker) below.
+
+---
+
+## Quick start (Docker)
+
+> **Requires:** Docker Engine ≥ 24 and Docker Compose v2.
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/bajdero/BID.git
+cd BID
+
+# 2. Copy and configure environment variables
+cp .env.example .env
+# Edit .env — at minimum set SECRET_KEY to a long random string
+
+# 3. Build and start all services
+docker compose up --build -d
+
+# 4. Open the application
+#    Web UI:       http://localhost/
+#    API docs:     http://localhost/docs
+#    FileBrowser:  http://localhost/files
+```
+
+> Default admin credentials are created on first run. See `src/api/` for the seeding logic.
+
+To stop: `docker compose down`  
+To view logs: `docker compose logs -f`
+
 ---
 
 ## Wymagania systemowe / System Requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+# BID 2.0.0-rc1 Docker Compose Stack
+# POC-01: Docker Compose with Nginx, API, Frontend, FileBrowser
+#
+# Start:   docker compose up --build -d
+# Stop:    docker compose down
+# Logs:    docker compose logs -f
+#
+# Environment variables — copy .env.example to .env before running
+
+services:
+  # ── Nginx reverse proxy ────────────────────────────────────────────────────
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      api:
+        condition: service_healthy
+      frontend:
+        condition: service_started
+    restart: unless-stopped
+
+  # ── FastAPI backend ────────────────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: src/Dockerfile
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-sqlite:////data/bid.sqlite3}
+      SECRET_KEY: ${SECRET_KEY}
+      PROJECTS_DIR: ${PROJECTS_DIR:-/data/projects}
+      CORS_ORIGINS: '["http://localhost", "http://localhost:80"]'
+      MAX_CONCURRENT_TASKS: ${MAX_CONCURRENT_TASKS:-2}
+    volumes:
+      - bid_data:/data
+    expose:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+
+  # ── React frontend ─────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: src/frontend
+      dockerfile: Dockerfile
+    expose:
+      - "80"
+    restart: unless-stopped
+
+  # ── FileBrowser ────────────────────────────────────────────────────────────
+  filebrowser:
+    image: filebrowser/filebrowser:latest
+    volumes:
+      - bid_data:/srv
+      - filebrowser_db:/database
+    environment:
+      FB_BASEURL: /files
+    expose:
+      - "80"
+    restart: unless-stopped
+
+volumes:
+  bid_data:
+  filebrowser_db:

--- a/migration_to_web_plan/implementation_plan.md
+++ b/migration_to_web_plan/implementation_plan.md
@@ -97,22 +97,23 @@ the Tkinter UI, with the photo processing pipeline as the first delivery priorit
 
 ---
 
-## Phase 3 — Frontend Shell
+## Phase 3 — Frontend Shell  ✅ COMPLETE
 
 **Milestone:** M3 — Frontend Shell (Phase 3)  
 **Due:** 2026-07-19  
+**Completed:** 2026-04-30  
 **Goal:** Scaffold the React TypeScript web application with routing, auth, and layout.
 
 ### Deliverables
 
 | ID | Title | Labels | Priority |
 |----|-------|--------|----------|
-| P3-01 | Bootstrap React + TypeScript + Vite project | type:infra, area:frontend | p0 |
-| P3-02 | Configure client-side routing (React Router v6) | type:feature, area:frontend | p1 |
-| P3-03 | Implement authentication flow (login, session, logout) | type:feature, area:frontend | p0 |
-| P3-04 | Create base layout components (AppShell, Sidebar, Header) | type:feature, area:frontend | p1 |
-| P3-05 | Set up state management (Zustand) and API client layer | type:infra, area:frontend | p1 |
-| P3-06 | Configure GitHub Actions CI/CD pipeline for frontend | type:infra, area:devops | p1 |
+| P3-01 | Bootstrap React + TypeScript + Vite project | type:infra, area:frontend | p0 | ✅ done |
+| P3-02 | Configure client-side routing (React Router v6) | type:feature, area:frontend | p1 | ✅ done |
+| P3-03 | Implement authentication flow (login, session, logout) | type:feature, area:frontend | p0 | ✅ done |
+| P3-04 | Create base layout components (AppShell, Sidebar, Header) | type:feature, area:frontend | p1 | ✅ done |
+| P3-05 | Set up state management (Zustand) and API client layer | type:infra, area:frontend | p1 | ✅ done |
+| P3-06 | Configure GitHub Actions CI/CD pipeline for frontend | type:infra, area:devops | p1 | ✅ done |
 
 ### Acceptance criteria
 - Application builds and passes lint with zero errors.
@@ -121,22 +122,23 @@ the Tkinter UI, with the photo processing pipeline as the first delivery priorit
 
 ---
 
-## Phase 4 — Core UI Components
+## Phase 4 — Core UI Components  ✅ COMPLETE
 
 **Milestone:** M4 — Core UI Components (Phase 4)  
 **Due:** 2026-09-06  
+**Completed:** 2026-04-30  
 **Goal:** Implement the primary interactive components that mirror the existing Tkinter panels.
 
 ### Deliverables
 
-| ID | Title | Labels | Priority |
-|----|-------|--------|----------|
-| P4-01 | Project/session selector (replaces `bid/ui/project_selector.py`) | type:feature, area:frontend | p0 |
-| P4-02 | Export profile configuration wizard (replaces `bid/ui/export_wizard.py`) | type:feature, area:frontend | p0 |
-| P4-03 | Image processing queue display with live status | type:feature, area:frontend | p0 |
-| P4-04 | Settings and preferences panel (replaces `bid/ui/setup_wizard.py`) | type:feature, area:frontend | p1 |
-| P4-05 | Toast notification system (replaces `bid/ui/toast.py`) | type:feature, area:frontend | p1 |
-| P4-06 | Theme provider — dark / light mode | type:feature, area:frontend | p2 |
+| ID | Title | Labels | Priority | Status |
+|----|-------|--------|----------|--------|
+| P4-01 | Project/session selector (replaces `bid/ui/project_selector.py`) | type:feature, area:frontend | p0 | ✅ done |
+| P4-02 | Export profile configuration wizard (replaces `bid/ui/export_wizard.py`) | type:feature, area:frontend | p0 | ✅ done |
+| P4-03 | Image processing queue display with live status | type:feature, area:frontend | p0 | ✅ done |
+| P4-04 | Settings and preferences panel (replaces `bid/ui/setup_wizard.py`) | type:feature, area:frontend | p1 | ✅ done |
+| P4-05 | Toast notification system (replaces `bid/ui/toast.py`) | type:feature, area:frontend | p1 | ✅ done |
+| P4-06 | Theme provider — dark / light mode | type:feature, area:frontend | p2 | ✅ done |
 
 ### Acceptance criteria
 - All export profile options available in `export_option.json` are configurable from the UI.
@@ -146,21 +148,22 @@ the Tkinter UI, with the photo processing pipeline as the first delivery priorit
 
 ---
 
-## PoC Release Readiness
+## PoC Release Readiness  ✅ COMPLETE
 
 **Milestone:** M5 — PoC Release 2.0.0-rc1  
 **Due:** 2026-09-20  
+**Completed:** 2026-04-30  
 **Goal:** Deliver a working end-to-end PoC of the web application for stakeholder validation.
 
 ### Deliverables
 
-| ID | Title | Labels | Priority |
-|----|-------|--------|----------|
-| POC-01 | End-to-end integration: connect frontend Phase 3–4 to Phase 1–2 backend | type:task, area:backend | p0 |
-| POC-02 | PoC smoke test suite covering the critical user journey | type:test, area:qa | p0 |
-| POC-03 | Tag and publish release package 2.0.0-rc1 | type:release | p0 |
-| POC-04 | Deploy 2.0.0-rc1 to staging environment | type:infra, area:devops | p0 |
-| POC-05 | Conduct PoC stakeholder demo and collect feedback | type:task | p1 |
+| ID | Title | Labels | Priority | Status |
+|----|-------|--------|----------|--------|
+| POC-01 | End-to-end integration: connect frontend Phase 3–4 to Phase 1–2 backend | type:task, area:backend | p0 | ✅ done |
+| POC-02 | PoC smoke test suite covering the critical user journey | type:test, area:qa | p0 | ✅ done |
+| POC-03 | Tag and publish release package 2.0.0-rc1 | type:release | p0 | ✅ done (tag pending) |
+| POC-04 | Deploy 2.0.0-rc1 to staging environment | type:infra, area:devops | p0 | ⏳ staging TBD |
+| POC-05 | Conduct PoC stakeholder demo and collect feedback | type:task | p1 | ⏳ pending |
 
 ### Acceptance criteria
 - User can log in, select a project, trigger batch processing, and see real-time progress.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,68 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+
+    access_log /var/log/nginx/access.log main;
+    sendfile on;
+    keepalive_timeout 65;
+
+    # ── Upstream definitions ──────────────────────────────────────────────
+    upstream api_upstream {
+        server api:8000;
+    }
+
+    upstream frontend_upstream {
+        server frontend:80;
+    }
+
+    upstream filebrowser_upstream {
+        server filebrowser:80;
+    }
+
+    # ── Main server block ─────────────────────────────────────────────────
+    server {
+        listen 80;
+        server_name _;
+        client_max_body_size 500M;
+
+        # ── API routes (/api and /health /version /docs /redoc /openapi.json)
+        location ~ ^/(api|health|version|docs|redoc|openapi\.json) {
+            proxy_pass http://api_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            # WebSocket upgrade support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400s;
+        }
+
+        # ── FileBrowser ──────────────────────────────────────────────────
+        location /files {
+            proxy_pass http://filebrowser_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # ── Frontend (SPA) — catch-all ───────────────────────────────────
+        location / {
+            proxy_pass http://frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,30 @@
+# BID API — FastAPI backend
+FROM python:3.11-slim AS base
+
+# Install system dependencies for Pillow, ExifTool, etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libimage-exiftool-perl \
+    libpng-dev \
+    libjpeg-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY src/requirements-api.txt /app/requirements-api.txt
+RUN pip install --no-cache-dir -r requirements-api.txt
+
+# Copy application code
+COPY bid/ /app/bid/
+COPY src/ /app/src/
+
+# Data directory (mounted as volume in docker compose)
+RUN mkdir -p /data/source /data/export
+
+ENV PYTHONPATH=/app
+ENV DATABASE_URL=sqlite:////data/bid.sqlite3
+ENV PROJECTS_DIR=/data/projects
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -26,7 +26,7 @@ from src.api.config import settings
 from src.api.deps import require_authenticated_user
 from src.api.errors import register_exception_handlers
 from src.api.models.database import init_db
-from src.api.routers import auth, exports, processing, projects, system, users
+from src.api.routers import auth, exports, processing, projects, sources, system, users
 from src.api.services.events import EventBroadcastService, set_event_service, get_event_service
 from src.api.services.processing import ProcessingService, set_service, get_service
 from src.api.websocket import router as ws_router
@@ -223,6 +223,11 @@ def create_app() -> FastAPI:
     )
     app.include_router(
         projects.router,
+        prefix=prefix,
+        dependencies=[Depends(require_authenticated_user)],
+    )
+    app.include_router(
+        sources.router,
         prefix=prefix,
         dependencies=[Depends(require_authenticated_user)],
     )

--- a/src/api/routers/sources.py
+++ b/src/api/routers/sources.py
@@ -1,0 +1,62 @@
+"""
+src/api/routers/sources.py
+Source-index read endpoints.
+
+GET  /projects/{project_id}/sources          — full source tree (P4-04)
+GET  /projects/{project_id}/sources/{folder}/{photo}  — single photo entry
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_db, get_source_service
+from src.api.schemas.common import ErrorResponse
+from src.api.schemas.source import PhotoEntry, SourceTree
+from src.api.services.source import SourceService
+
+_ERR = {
+    404: {"model": ErrorResponse, "description": "Project or photo not found."},
+}
+
+router = APIRouter(prefix="/projects/{project_id}/sources", tags=["sources"])
+
+
+@router.get(
+    "",
+    response_model=SourceTree,
+    summary="Get project source tree",
+    responses=_ERR,
+)
+def get_source_tree(
+    project_id: str,
+    db: Session = Depends(get_db),
+    svc: SourceService = Depends(get_source_service),
+) -> SourceTree:
+    """Return the full folder→photo index for the given project."""
+    return svc.get_source_tree(db=db, project_id=project_id)
+
+
+@router.get(
+    "/{folder}/{photo}",
+    response_model=PhotoEntry,
+    summary="Get a single photo entry",
+    responses=_ERR,
+)
+def get_photo(
+    project_id: str,
+    folder: str,
+    photo: str,
+    db: Session = Depends(get_db),
+    svc: SourceService = Depends(get_source_service),
+) -> PhotoEntry:
+    """Return the metadata record for a single source photo."""
+    from src.api.services.source import _record_to_entry  # noqa: PLC0415
+
+    record = svc.get_photo(db=db, project_id=project_id, folder=folder, filename=photo)
+    if record is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Photo '{folder}/{photo}' not found in project '{project_id}'.",
+        )
+    return _record_to_entry(record)

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: Build
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci --prefer-offline
+
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve static files via nginx
+FROM nginx:alpine AS runtime
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+)

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BID — Batch Image Delivery</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — serve index.html for all unknown paths
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "bid-frontend",
+  "private": true,
+  "version": "2.0.0-rc1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --ext ts,tsx --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
+    "zustand": "^5.0.0",
+    "axios": "^1.7.7",
+    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-dropdown-menu": "^2.1.2",
+    "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.2",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-scroll-area": "^1.2.1",
+    "@radix-ui/react-progress": "^1.1.0",
+    "@radix-ui/react-badge": "^1.0.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.460.0",
+    "tailwind-merge": "^2.5.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
+    "@typescript-eslint/eslint-plugin": "^8.11.0",
+    "@typescript-eslint/parser": "^8.11.0",
+    "@vitejs/plugin-react": "^4.3.3",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.13.0",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.13",
+    "globals": "^15.11.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/src/frontend/postcss.config.js
+++ b/src/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,0 +1,51 @@
+/**
+ * src/App.tsx
+ * Application root — React Router v6 client-side routing (P3-01, P3-02, P3-03).
+ *
+ * Route structure:
+ *   /login          — public login page
+ *   /               — protected: dashboard
+ *   /projects       — protected: project selector
+ *   /sources        — protected: source tree (requires active project)
+ *   /processing     — protected: processing queue with WebSocket
+ *   /exports        — protected: export profile wizard
+ *   /settings       — protected: settings & preferences
+ *   *               — 404 page
+ */
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { AppShell } from '@/components/layout/AppShell'
+import { RequireAuth } from '@/components/auth/RequireAuth'
+import LoginPage from '@/pages/LoginPage'
+import DashboardPage from '@/pages/DashboardPage'
+import ProjectsPage from '@/pages/ProjectsPage'
+import SourcesPage from '@/pages/SourcesPage'
+import ProcessingPage from '@/pages/ProcessingPage'
+import ExportsPage from '@/pages/ExportsPage'
+import SettingsPage from '@/pages/SettingsPage'
+import NotFoundPage from '@/pages/NotFoundPage'
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* Public routes */}
+        <Route path="/login" element={<LoginPage />} />
+
+        {/* Protected routes wrapped in AppShell + RequireAuth */}
+        <Route element={<RequireAuth />}>
+          <Route element={<AppShell />}>
+            <Route index element={<DashboardPage />} />
+            <Route path="projects" element={<ProjectsPage />} />
+            <Route path="sources" element={<SourcesPage />} />
+            <Route path="processing" element={<ProcessingPage />} />
+            <Route path="exports" element={<ExportsPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+          </Route>
+        </Route>
+
+        {/* 404 — catches all unmatched routes */}
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/src/frontend/src/components/Toaster.tsx
+++ b/src/frontend/src/components/Toaster.tsx
@@ -1,0 +1,33 @@
+/**
+ * src/components/Toaster.tsx
+ * Global toast notification container (P4-05).
+ */
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from '@/components/ui/toast'
+import { useToast } from '@/hooks/useToast'
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, ...props }) => (
+        <Toast key={id} {...props}>
+          <div className="grid gap-1">
+            {title && <ToastTitle>{title}</ToastTitle>}
+            {description && <ToastDescription>{description}</ToastDescription>}
+          </div>
+          {action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/src/frontend/src/components/auth/RequireAuth.tsx
+++ b/src/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,17 @@
+/**
+ * src/components/auth/RequireAuth.tsx
+ * Route guard — redirects unauthenticated users to /login (P3-03).
+ */
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
+
+export function RequireAuth() {
+  const { isAuthenticated } = useAuthStore()
+  const location = useLocation()
+
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  return <Outlet />
+}

--- a/src/frontend/src/components/layout/AppShell.tsx
+++ b/src/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,23 @@
+/**
+ * src/components/layout/AppShell.tsx
+ * Root layout wrapper — header + sidebar + main content area (P3-04).
+ */
+import { Outlet } from 'react-router-dom'
+import { Header } from './Header'
+import { Sidebar } from './Sidebar'
+import { Toaster } from '@/components/Toaster'
+
+export function AppShell() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-6">
+          <Outlet />
+        </main>
+      </div>
+      <Toaster />
+    </div>
+  )
+}

--- a/src/frontend/src/components/layout/Header.tsx
+++ b/src/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,53 @@
+/**
+ * src/components/layout/Header.tsx
+ * Application header with user menu (P3-04).
+ */
+import { Link, useNavigate } from 'react-router-dom'
+import { LogOut, User, Settings, LayoutDashboard } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/store/authStore'
+import { toast } from '@/hooks/useToast'
+
+export function Header() {
+  const { user, logout, isAuthenticated } = useAuthStore()
+  const navigate = useNavigate()
+
+  function handleLogout() {
+    logout()
+    toast({ title: 'Logged out', description: 'You have been signed out.' })
+    navigate('/login')
+  }
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="flex h-14 items-center px-4 gap-4">
+        <Link to="/" className="flex items-center gap-2 font-bold text-lg">
+          <LayoutDashboard className="h-5 w-5" />
+          <span>BID</span>
+        </Link>
+
+        <div className="flex-1" />
+
+        {isAuthenticated() && (
+          <div className="flex items-center gap-2">
+            <Link to="/settings">
+              <Button variant="ghost" size="icon" title="Settings">
+                <Settings className="h-4 w-4" />
+              </Button>
+            </Link>
+
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <User className="h-4 w-4" />
+              <span>{user?.username ?? 'User'}</span>
+            </div>
+
+            <Button variant="ghost" size="sm" onClick={handleLogout}>
+              <LogOut className="h-4 w-4 mr-1" />
+              Logout
+            </Button>
+          </div>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,70 @@
+/**
+ * src/components/layout/Sidebar.tsx
+ * Navigation sidebar (P3-04).
+ */
+import { NavLink } from 'react-router-dom'
+import {
+  FolderOpen,
+  ImagePlus,
+  LayoutDashboard,
+  Settings,
+  TreePine,
+  Download,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useProjectStore } from '@/store/projectStore'
+
+interface NavItem {
+  to: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  requiresProject?: boolean
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { to: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { to: '/projects', label: 'Projects', icon: FolderOpen },
+  { to: '/sources', label: 'Source Tree', icon: TreePine, requiresProject: true },
+  { to: '/processing', label: 'Processing', icon: ImagePlus, requiresProject: true },
+  { to: '/exports', label: 'Export', icon: Download, requiresProject: true },
+  { to: '/settings', label: 'Settings', icon: Settings },
+]
+
+export function Sidebar() {
+  const { selectedProject } = useProjectStore()
+
+  return (
+    <aside className="hidden md:flex w-56 flex-col border-r bg-card">
+      <nav className="flex flex-col gap-1 p-3 pt-4">
+        {NAV_ITEMS.map(({ to, label, icon: Icon, requiresProject }) => {
+          const disabled = requiresProject && !selectedProject
+          return (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  disabled && 'pointer-events-none opacity-40',
+                )
+              }
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {label}
+            </NavLink>
+          )
+        })}
+      </nav>
+
+      {selectedProject && (
+        <div className="mt-auto p-3 border-t">
+          <p className="text-xs text-muted-foreground mb-1">Active project</p>
+          <p className="text-sm font-medium truncate">{selectedProject.name}</p>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/src/frontend/src/components/ui/button.tsx
+++ b/src/frontend/src/components/ui/button.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/src/frontend/src/components/ui/card.tsx
+++ b/src/frontend/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  ),
+)
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+)
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+)
+CardTitle.displayName = 'CardTitle'
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+))
+CardDescription.displayName = 'CardDescription'
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+)
+CardContent.displayName = 'CardContent'
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+)
+CardFooter.displayName = 'CardFooter'
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/frontend/src/components/ui/input.tsx
+++ b/src/frontend/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/src/frontend/src/components/ui/label.tsx
+++ b/src/frontend/src/components/ui/label.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/frontend/src/components/ui/progress.tsx
+++ b/src/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import * as ProgressPrimitive from '@radix-ui/react-progress'
+import { cn } from '@/lib/utils'
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      className,
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/frontend/src/components/ui/toast.tsx
+++ b/src/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import * as ToastPrimitive from '@radix-ui/react-toast'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const ToastProvider = ToastPrimitive.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      className,
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitive.Viewport.displayName
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  {
+    variants: {
+      variant: {
+        default: 'border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitive.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitive.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      className,
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitive.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Close
+    ref={ref}
+    className={cn(
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitive.Close>
+))
+ToastClose.displayName = ToastPrimitive.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Title
+    ref={ref}
+    className={cn('text-sm font-semibold', className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitive.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitive.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/src/frontend/src/hooks/useToast.ts
+++ b/src/frontend/src/hooks/useToast.ts
@@ -1,0 +1,137 @@
+/**
+ * src/hooks/useToast.ts
+ * Toast notification hook — messages disappear after 5 s (P4-05).
+ */
+import * as React from 'react'
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast'
+
+const TOAST_LIMIT = 5
+const TOAST_REMOVE_DELAY_MS = 5000
+
+type ToastVariant = 'default' | 'destructive'
+
+interface ToasterToast extends Omit<ToastProps, 'variant'> {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+  variant?: ToastVariant
+}
+
+let count = 0
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type Action =
+  | { type: 'ADD_TOAST'; toast: ToasterToast }
+  | { type: 'UPDATE_TOAST'; toast: Partial<ToasterToast> & { id: string } }
+  | { type: 'DISMISS_TOAST'; toastId?: string }
+  | { type: 'REMOVE_TOAST'; toastId?: string }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+function addToRemoveQueue(toastId: string, dispatch: React.Dispatch<Action>) {
+  if (toastTimeouts.has(toastId)) return
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({ type: 'REMOVE_TOAST', toastId })
+  }, TOAST_REMOVE_DELAY_MS)
+  toastTimeouts.set(toastId, timeout)
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+        ),
+      }
+    case 'DISMISS_TOAST': {
+      const { toastId } = action
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? { ...t, open: false }
+            : t,
+        ),
+      }
+    }
+    case 'REMOVE_TOAST':
+      return {
+        ...state,
+        toasts: action.toastId
+          ? state.toasts.filter((t) => t.id !== action.toastId)
+          : [],
+      }
+  }
+}
+
+const listeners: Array<React.Dispatch<Action>> = []
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => listener(action))
+}
+
+interface Toast extends Omit<ToasterToast, 'id'> {}
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+  const update = (props: ToasterToast) => dispatch({ type: 'UPDATE_TOAST', toast: { ...props, id } })
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id })
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return { id, dismiss, update }
+}
+
+function useToast() {
+  const [state, setStateDispatch] = React.useReducer(reducer, memoryState)
+
+  React.useEffect(() => {
+    const listener: React.Dispatch<Action> = (action) => {
+      setStateDispatch(action)
+      if (action.type === 'ADD_TOAST') {
+        addToRemoveQueue(action.toast.id, (a) => setStateDispatch(a))
+      }
+    }
+    listeners.push(listener)
+    return () => {
+      const index = listeners.indexOf(listener)
+      if (index > -1) listeners.splice(index, 1)
+    }
+  }, [])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1,0 +1,59 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/frontend/src/lib/apiClient.ts
+++ b/src/frontend/src/lib/apiClient.ts
@@ -1,0 +1,209 @@
+/**
+ * src/lib/apiClient.ts
+ * Axios-based API client that automatically injects the JWT Bearer token
+ * from the Zustand auth store and handles token refresh (P3-05).
+ */
+import axios, {
+  type AxiosError,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+import { useAuthStore } from '@/store/authStore'
+
+const BASE_URL = '/api/v1'
+
+export const apiClient = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// ---- Request interceptor: attach access token ----
+apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = useAuthStore.getState().accessToken
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+// ---- Response interceptor: handle 401 with silent refresh ----
+let isRefreshing = false
+let pendingRequests: Array<(token: string) => void> = []
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retried?: boolean
+    }
+
+    if (error.response?.status === 401 && !originalRequest._retried) {
+      originalRequest._retried = true
+
+      if (!isRefreshing) {
+        isRefreshing = true
+        const { refreshToken, setTokens, logout } = useAuthStore.getState()
+
+        try {
+          const res = await axios.post(`${BASE_URL}/auth/refresh`, {
+            refresh_token: refreshToken,
+          })
+          const { access_token, refresh_token } = res.data
+          setTokens(access_token, refresh_token)
+          pendingRequests.forEach((cb) => cb(access_token))
+          pendingRequests = []
+          isRefreshing = false
+          originalRequest.headers.Authorization = `Bearer ${access_token}`
+          return apiClient(originalRequest)
+        } catch {
+          logout()
+          isRefreshing = false
+          pendingRequests = []
+          return Promise.reject(error)
+        }
+      }
+
+      // Queue concurrent requests until refresh completes
+      return new Promise((resolve) => {
+        pendingRequests.push((token: string) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`
+          resolve(apiClient(originalRequest))
+        })
+      })
+    }
+
+    return Promise.reject(error)
+  },
+)
+
+// ---- Typed API helpers ----
+
+export interface LoginPayload {
+  username: string
+  password: string
+}
+
+export interface TokenResponse {
+  access_token: string
+  refresh_token: string
+  token_type: string
+}
+
+export const authApi = {
+  login: (payload: LoginPayload) =>
+    apiClient.post<TokenResponse>('/auth/login', payload),
+  refresh: (refreshToken: string) =>
+    apiClient.post<TokenResponse>('/auth/refresh', {
+      refresh_token: refreshToken,
+    }),
+}
+
+export interface ProjectResponse {
+  id: string
+  name: string
+  path: string
+  last_modified: string
+  photo_count: number
+  source_folder: string
+  export_folder: string
+}
+
+export const projectsApi = {
+  list: () => apiClient.get<ProjectResponse[]>('/projects'),
+  get: (id: string) => apiClient.get<ProjectResponse>(`/projects/${id}`),
+  create: (data: { name: string; source_folder: string; export_folder: string }) =>
+    apiClient.post<ProjectResponse>('/projects', data),
+  delete: (id: string) => apiClient.delete(`/projects/${id}`),
+}
+
+export interface PhotoEntry {
+  hash_id: string
+  path: string
+  state: 'downloading' | 'new' | 'processing' | 'ok' | 'ok_old' | 'error' | 'export_fail' | 'deleted' | 'skip'
+  exported: Record<string, string>
+  description: string
+  tags: string[]
+  size: string
+  size_bytes: number
+  created: string
+  mtime: number
+  exif: Record<string, string>
+  quality_score: number | null
+  quality_model: 'exif_rules' | 'ml' | null
+  error_msg: string | null
+  duration_sec: number | null
+  event_folder: string | null
+  event_id: string | null
+  event_name: string | null
+}
+
+export interface SourceTree {
+  folders: Record<string, Record<string, PhotoEntry>>
+}
+
+export const sourcesApi = {
+  getTree: (projectId: string) =>
+    apiClient.get<SourceTree>(`/projects/${projectId}/sources`),
+  getPhoto: (projectId: string, folder: string, photo: string) =>
+    apiClient.get<PhotoEntry>(`/projects/${projectId}/sources/${folder}/${photo}`),
+}
+
+export interface ExportProfile {
+  size_type: 'longer' | 'width' | 'height' | 'shorter'
+  size: number
+  format: 'JPEG' | 'PNG'
+  quality: number
+  ratio: [number, number] | null
+  logo: Record<string, unknown> | null
+  logo_required: boolean
+}
+
+export interface ExportProfilesResponse {
+  profiles: Record<string, ExportProfile>
+}
+
+export const exportsApi = {
+  getProfiles: (projectId: string) =>
+    apiClient.get<ExportProfilesResponse>(`/projects/${projectId}/export-profiles`),
+  updateProfiles: (projectId: string, data: ExportProfilesResponse) =>
+    apiClient.put<ExportProfilesResponse>(`/projects/${projectId}/export-profiles`, data),
+  validateProfile: (projectId: string, name: string, profile: ExportProfile) =>
+    apiClient.post<{ valid: boolean; errors: string[] }>(
+      `/projects/${projectId}/export-profiles/validate`,
+      { name, profile },
+    ),
+}
+
+export interface ProcessResponse {
+  task_id: string
+  queued: number
+  skipped: number
+  message: string
+}
+
+export interface ProcessStatusResponse {
+  queue_length: number
+  active: Array<{ folder: string; photo: string; state: string; profile: string | null }>
+  completed: number
+  failed: number
+}
+
+export const processingApi = {
+  enqueue: (projectId: string, photos: Array<[string, string]>, profiles?: string[]) =>
+    apiClient.post<ProcessResponse>(`/projects/${projectId}/process`, {
+      photos,
+      profiles: profiles ?? null,
+    }),
+  enqueueAll: (projectId: string) =>
+    apiClient.post<ProcessResponse>(`/projects/${projectId}/process/all`),
+  getStatus: (projectId: string) =>
+    apiClient.get<ProcessStatusResponse>(`/projects/${projectId}/process/status`),
+  resetPhoto: (projectId: string, folder: string, photo: string) =>
+    apiClient.delete(`/projects/${projectId}/process/${folder}/${photo}`),
+}
+
+export const systemApi = {
+  health: () => apiClient.get<{ status: string }>('/health'),
+  version: () => apiClient.get<{ api_version: string; bid_version: string }>('/version'),
+}

--- a/src/frontend/src/lib/utils.ts
+++ b/src/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/frontend/src/lib/wsClient.ts
+++ b/src/frontend/src/lib/wsClient.ts
@@ -1,0 +1,131 @@
+/**
+ * src/lib/wsClient.ts
+ * WebSocket client with heartbeat and auto-reconnect (P2-04, P3-05).
+ * Connects to /api/v1/projects/{projectId}/ws?token=<jwt>
+ */
+import { useAuthStore } from '@/store/authStore'
+
+export type WsMessageHandler = (msg: WsMessage) => void
+
+export interface WsMessage {
+  type: string
+  [key: string]: unknown
+}
+
+export interface WsClientOptions {
+  projectId: string
+  onMessage: WsMessageHandler
+  onConnect?: () => void
+  onDisconnect?: () => void
+  reconnectDelay?: number   // ms, default 3000
+  maxReconnects?: number    // default unlimited
+}
+
+const WS_BASE =
+  typeof window !== 'undefined'
+    ? `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
+    : 'ws://localhost'
+
+export class BidWebSocketClient {
+  private ws: WebSocket | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectCount = 0
+  private closed = false
+  private pingTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(private options: WsClientOptions) {}
+
+  connect(): void {
+    this.closed = false
+    this._openSocket()
+  }
+
+  disconnect(): void {
+    this.closed = true
+    this._clearTimers()
+    this.ws?.close()
+    this.ws = null
+  }
+
+  private _buildUrl(): string {
+    const { projectId } = this.options
+    const token = useAuthStore.getState().accessToken ?? ''
+    return `${WS_BASE}/api/v1/projects/${encodeURIComponent(projectId)}/ws?token=${encodeURIComponent(token)}`
+  }
+
+  private _openSocket(): void {
+    try {
+      this.ws = new WebSocket(this._buildUrl())
+    } catch {
+      this._scheduleReconnect()
+      return
+    }
+
+    this.ws.onopen = () => {
+      this.reconnectCount = 0
+      this.options.onConnect?.()
+      this._startPing()
+    }
+
+    this.ws.onmessage = (evt: MessageEvent<string>) => {
+      try {
+        const msg = JSON.parse(evt.data) as WsMessage
+        if (msg.type === 'ping') {
+          this.ws?.send(JSON.stringify({ type: 'pong' }))
+          return
+        }
+        if (msg.type === 'server_closing') {
+          const delay = typeof msg.reconnect_after === 'number'
+            ? msg.reconnect_after * 1000
+            : this.options.reconnectDelay ?? 3000
+          this._scheduleReconnect(delay)
+          return
+        }
+        this.options.onMessage(msg)
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    this.ws.onerror = () => {
+      // onclose will follow
+    }
+
+    this.ws.onclose = () => {
+      this._clearTimers()
+      this.options.onDisconnect?.()
+      if (!this.closed) {
+        this._scheduleReconnect()
+      }
+    }
+  }
+
+  private _startPing(): void {
+    this.pingTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'pong' })) // respond to server pings
+      }
+    }, 25000)
+  }
+
+  private _clearTimers(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    if (this.pingTimer !== null) {
+      clearInterval(this.pingTimer)
+      this.pingTimer = null
+    }
+  }
+
+  private _scheduleReconnect(delay?: number): void {
+    const { maxReconnects, reconnectDelay = 3000 } = this.options
+    if (maxReconnects !== undefined && this.reconnectCount >= maxReconnects) return
+    const ms = delay ?? reconnectDelay
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectCount++
+      this._openSocket()
+    }, ms)
+  }
+}

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/src/frontend/src/pages/DashboardPage.tsx
+++ b/src/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,121 @@
+/**
+ * src/pages/DashboardPage.tsx
+ * Main dashboard — shows active project summary and quick actions.
+ */
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { FolderOpen, ImagePlus, Loader2 } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useProjectStore } from '@/store/projectStore'
+import { useAuthStore } from '@/store/authStore'
+import { projectsApi } from '@/lib/apiClient'
+
+export default function DashboardPage() {
+  const { user } = useAuthStore()
+  const { projects, selectedProject, setProjects, setLoading, isLoading } = useProjectStore()
+
+  useEffect(() => {
+    setLoading(true)
+    projectsApi
+      .list()
+      .then((res) => setProjects(res.data))
+      .catch(() => {/* ignore */})
+      .finally(() => setLoading(false))
+  }, [setLoading, setProjects])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+        <p className="text-muted-foreground">
+          Welcome back, {user?.username ?? 'User'}
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Active Project</CardTitle>
+            <FolderOpen className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {selectedProject ? (
+              <>
+                <p className="text-2xl font-bold">{selectedProject.name}</p>
+                <p className="text-xs text-muted-foreground truncate mt-1">
+                  {selectedProject.source_folder}
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-muted-foreground">No project selected</p>
+                <Button asChild size="sm" className="mt-2">
+                  <Link to="/projects">Select a project</Link>
+                </Button>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Projects</CardTitle>
+            <FolderOpen className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <p className="text-2xl font-bold">{projects.length}</p>
+            )}
+            <p className="text-xs text-muted-foreground mt-1">Total projects</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">Quick Actions</CardTitle>
+            <ImagePlus className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Button asChild variant="outline" size="sm" className="w-full">
+              <Link to="/projects">Manage Projects</Link>
+            </Button>
+            {selectedProject && (
+              <Button asChild size="sm" className="w-full">
+                <Link to="/processing">Start Processing</Link>
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {selectedProject && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Project: {selectedProject.name}</CardTitle>
+            <CardDescription>
+              Source: {selectedProject.source_folder} → Export:{' '}
+              {selectedProject.export_folder}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex gap-2">
+            <Button asChild>
+              <Link to="/sources">Browse Sources</Link>
+            </Button>
+            <Button asChild variant="secondary">
+              <Link to="/exports">Export Config</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/frontend/src/pages/ExportsPage.tsx
+++ b/src/frontend/src/pages/ExportsPage.tsx
@@ -1,0 +1,231 @@
+﻿/**
+ * src/pages/ExportsPage.tsx
+ * Export profile configuration (P4-02).
+ * Replaces bid/ui/export_wizard.py
+ *
+ * Loads profiles from GET /projects/{id}/export-profiles, lets the user
+ * add / edit / delete profiles, and saves with PUT.
+ */
+import { useEffect, useState } from 'react'
+import { Plus, Trash2, Save, Loader2 } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useProjectStore } from '@/store/projectStore'
+import { exportsApi, type ExportProfile } from '@/lib/apiClient'
+import { useToast } from '@/hooks/useToast'
+
+const DEFAULT_PROFILE: ExportProfile = {
+  size_type: 'longer',
+  size: 1200,
+  format: 'JPEG',
+  quality: 85,
+  ratio: null,
+  logo: null,
+  logo_required: false,
+}
+
+export default function ExportsPage() {
+  const { selectedProject } = useProjectStore()
+  const { toast: addToast } = useToast()
+  const [profiles, setProfiles] = useState<Record<string, ExportProfile>>({})
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [newName, setNewName] = useState('')
+
+  useEffect(() => {
+    if (!selectedProject) return
+    setLoading(true)
+    exportsApi
+      .getProfiles(selectedProject.id)
+      .then((res) => setProfiles(res.data.profiles))
+      .catch(() => addToast({ title: 'Failed to load export profiles', variant: 'destructive' }))
+      .finally(() => setLoading(false))
+  }, [selectedProject])
+
+  function updateField<K extends keyof ExportProfile>(
+    name: string,
+    key: K,
+    value: ExportProfile[K],
+  ) {
+    setProfiles((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], [key]: value },
+    }))
+  }
+
+  function addProfile() {
+    const trimmed = newName.trim()
+    if (!trimmed) return
+    if (profiles[trimmed]) {
+      addToast({ title: `Profile "${trimmed}" already exists`, variant: 'destructive' })
+      return
+    }
+    setProfiles((prev) => ({ ...prev, [trimmed]: { ...DEFAULT_PROFILE } }))
+    setNewName('')
+  }
+
+  function removeProfile(name: string) {
+    setProfiles((prev) => {
+      const copy = { ...prev }
+      delete copy[name]
+      return copy
+    })
+  }
+
+  async function saveProfiles() {
+    if (!selectedProject) return
+    setSaving(true)
+    try {
+      await exportsApi.updateProfiles(selectedProject.id, { profiles })
+      addToast({ title: 'Export profiles saved' })
+    } catch {
+      addToast({ title: 'Failed to save export profiles', variant: 'destructive' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!selectedProject) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+        <p>No project selected. Select a project first.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Export Profiles</h1>
+          <p className="text-muted-foreground">
+            Configure output size, format, and quality for {selectedProject.name}
+          </p>
+        </div>
+        <Button onClick={saveProfiles} disabled={saving}>
+          {saving ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="mr-2 h-4 w-4" />
+          )}
+          {saving ? 'Savingâ€¦' : 'Save All'}
+        </Button>
+      </div>
+
+      {loading && (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Profile cards */}
+      {Object.entries(profiles).map(([name, profile]) => (
+        <Card key={name}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-lg">{name}</CardTitle>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => removeProfile(name)}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              {/* size_type */}
+              <div className="space-y-1.5">
+                <Label>Size Type</Label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={profile.size_type}
+                  onChange={(e) =>
+                    updateField(name, 'size_type', e.target.value as ExportProfile['size_type'])
+                  }
+                >
+                  {(['longer', 'shorter', 'width', 'height'] as const).map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* size */}
+              <div className="space-y-1.5">
+                <Label>Size (px)</Label>
+                <Input
+                  type="number"
+                  min={100}
+                  max={10000}
+                  value={profile.size}
+                  onChange={(e) => updateField(name, 'size', Number(e.target.value))}
+                />
+              </div>
+
+              {/* format */}
+              <div className="space-y-1.5">
+                <Label>Format</Label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={profile.format}
+                  onChange={(e) =>
+                    updateField(name, 'format', e.target.value as ExportProfile['format'])
+                  }
+                >
+                  <option value="JPEG">JPEG</option>
+                  <option value="PNG">PNG</option>
+                </select>
+              </div>
+
+              {/* quality */}
+              <div className="space-y-1.5">
+                <Label>Quality (1â€“100)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={100}
+                  value={profile.quality}
+                  onChange={(e) => updateField(name, 'quality', Number(e.target.value))}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+
+      {!loading && Object.keys(profiles).length === 0 && (
+        <div className="text-center py-12 text-muted-foreground">
+          No export profiles configured. Add one below.
+        </div>
+      )}
+
+      {/* Add new profile */}
+      <Card className="border-dashed">
+        <CardContent className="pt-6">
+          <div className="flex gap-2">
+            <Input
+              placeholder="New profile name (e.g. web)"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && addProfile()}
+              className="max-w-xs"
+            />
+            <Button variant="outline" onClick={addProfile} disabled={!newName.trim()}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Profile
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,100 @@
+/**
+ * src/pages/LoginPage.tsx
+ * Login form page — authenticates and stores JWT tokens (P3-03).
+ */
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { LayoutDashboard, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { useAuthStore } from '@/store/authStore'
+import { authApi } from '@/lib/apiClient'
+import { toast } from '@/hooks/useToast'
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const { setTokens } = useAuthStore()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname ?? '/'
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setIsLoading(true)
+
+    try {
+      const res = await authApi.login({ username, password })
+      setTokens(res.data.access_token, res.data.refresh_token)
+      toast({ title: 'Welcome back!', description: `Signed in as ${username}` })
+      navigate(from, { replace: true })
+    } catch {
+      setError('Invalid username or password.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="space-y-1 text-center">
+          <div className="flex justify-center mb-2">
+            <LayoutDashboard className="h-8 w-8" />
+          </div>
+          <CardTitle className="text-2xl">BID</CardTitle>
+          <CardDescription>Batch Image Delivery — sign in to continue</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                type="text"
+                placeholder="username"
+                autoComplete="username"
+                required
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="••••••••"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isLoading ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/NotFoundPage.tsx
+++ b/src/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,21 @@
+/**
+ * src/pages/NotFoundPage.tsx
+ * 404 page for unknown routes (P3-02).
+ */
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+      <h1 className="text-6xl font-bold text-muted-foreground">404</h1>
+      <p className="text-xl font-semibold">Page not found</p>
+      <p className="text-muted-foreground max-w-sm">
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <Button asChild>
+        <Link to="/">Return to dashboard</Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/ProcessingPage.tsx
+++ b/src/frontend/src/pages/ProcessingPage.tsx
@@ -1,0 +1,266 @@
+/**
+ * src/pages/ProcessingPage.tsx
+ * Image processing queue with real-time WebSocket status updates (P4-03).
+ * Replaces bid/ui/preview.py queue functionality.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { Play, RotateCcw, Loader2, Wifi, WifiOff } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { useProjectStore } from '@/store/projectStore'
+import { useProcessingStore, type PhotoStatus } from '@/store/processingStore'
+import { processingApi } from '@/lib/apiClient'
+import { BidWebSocketClient, type WsMessage } from '@/lib/wsClient'
+import { toast } from '@/hooks/useToast'
+import { cn } from '@/lib/utils'
+
+const STATUS_LABEL: Record<PhotoStatus, string> = {
+  new: 'Pending',
+  processing: 'Processing…',
+  done: 'Done',
+  error: 'Error',
+  skipped: 'Skipped',
+}
+
+const STATUS_COLOUR: Record<PhotoStatus, string> = {
+  new: 'text-muted-foreground',
+  processing: 'text-yellow-500',
+  done: 'text-green-500',
+  error: 'text-red-500',
+  skipped: 'text-muted-foreground',
+}
+
+export default function ProcessingPage() {
+  const { selectedProject } = useProjectStore()
+  const { queue, metrics, upsertQueueItem, updateQueueItem, setMetrics, setIsProcessing, isProcessing, clearQueue } =
+    useProcessingStore()
+
+  const [wsConnected, setWsConnected] = useState(false)
+  const [isEnqueuing, setIsEnqueuing] = useState(false)
+  const wsRef = useRef<BidWebSocketClient | null>(null)
+
+  // Connect WebSocket when a project is selected
+  useEffect(() => {
+    if (!selectedProject) return
+
+    const client = new BidWebSocketClient({
+      projectId: selectedProject.id,
+      reconnectDelay: 3000,
+      onConnect: () => setWsConnected(true),
+      onDisconnect: () => setWsConnected(false),
+      onMessage: (msg: WsMessage) => {
+        switch (msg.type) {
+          case 'state_change': {
+            const { photo, folder, new_state } = msg as {
+              photo: string
+              folder: string
+              new_state: string
+            }
+            upsertQueueItem({
+              id: `${folder}/${photo}`,
+              photo: photo as string,
+              folder: folder as string,
+              status: new_state as PhotoStatus,
+            })
+            if (new_state === 'processing') setIsProcessing(true)
+            break
+          }
+          case 'progress': {
+            const { photo, folder, status } = msg as {
+              photo: string
+              folder: string
+              status: string
+            }
+            updateQueueItem(`${folder}/${photo}`, { status: status as PhotoStatus })
+            if (status === 'completed' || status === 'failed') {
+              // Check if all done
+              const allDone = queue.every((q) => q.status === 'done' || q.status === 'error' || q.status === 'skipped')
+              if (allDone) setIsProcessing(false)
+            }
+            break
+          }
+          case 'queue_metrics': {
+            setMetrics(msg as unknown as typeof metrics)
+            break
+          }
+          case 'error': {
+            toast({
+              title: 'Processing error',
+              description: String(msg.message ?? 'Unknown error'),
+              variant: 'destructive',
+            })
+            break
+          }
+        }
+      },
+    })
+
+    wsRef.current = client
+    client.connect()
+
+    return () => {
+      client.disconnect()
+      wsRef.current = null
+    }
+  }, [selectedProject, upsertQueueItem, updateQueueItem, setMetrics, setIsProcessing, queue])
+
+  async function handleEnqueueAll() {
+    if (!selectedProject) return
+    setIsEnqueuing(true)
+    clearQueue()
+    try {
+      const res = await processingApi.enqueueAll(selectedProject.id)
+      setIsProcessing(true)
+      toast({
+        title: 'Processing started',
+        description: `${res.data.queued} photo(s) enqueued`,
+      })
+    } catch {
+      toast({ title: 'Error', description: 'Failed to start processing', variant: 'destructive' })
+    } finally {
+      setIsEnqueuing(false)
+    }
+  }
+
+  async function handleReset() {
+    if (!selectedProject) return
+    clearQueue()
+    setIsProcessing(false)
+    toast({ title: 'Queue cleared', description: 'Client queue cleared (photos keep their state)' })
+  }
+
+  if (!selectedProject) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[40vh] gap-2 text-center">
+        <p className="text-muted-foreground">Select a project to start processing</p>
+      </div>
+    )
+  }
+
+  const doneCount = queue.filter((q) => q.status === 'done').length
+  const totalCount = queue.length
+  const progress = totalCount > 0 ? (doneCount / totalCount) * 100 : 0
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Processing</h1>
+          <p className="text-muted-foreground">{selectedProject.name}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={cn('flex items-center gap-1 text-xs', wsConnected ? 'text-green-500' : 'text-muted-foreground')}>
+            {wsConnected ? <Wifi className="h-3 w-3" /> : <WifiOff className="h-3 w-3" />}
+            {wsConnected ? 'Live' : 'Offline'}
+          </span>
+          <Button variant="outline" size="sm" onClick={handleReset} disabled={isProcessing}>
+            <RotateCcw className="h-4 w-4 mr-1" />
+            Reset
+          </Button>
+          <Button size="sm" onClick={handleEnqueueAll} disabled={isEnqueuing || isProcessing}>
+            {isEnqueuing ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4 mr-1" />
+            )}
+            {isProcessing ? 'Processing…' : 'Start Processing'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Metrics */}
+      {metrics && (
+        <div className="grid gap-4 md:grid-cols-4">
+          {[
+            { label: 'Queue', value: metrics.queue_length },
+            { label: 'Active', value: metrics.active_workers },
+            { label: 'Completed', value: metrics.completed_total },
+            { label: 'Failed', value: metrics.failed_total },
+          ].map(({ label, value }) => (
+            <Card key={label}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">{label}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold">{value}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Progress bar */}
+      {totalCount > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>
+              {doneCount} / {totalCount} completed
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Progress value={progress} className="h-3" />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Queue table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Queue</CardTitle>
+          <CardDescription>
+            {queue.length === 0
+              ? 'No items in queue. Click "Start Processing" to enqueue photos.'
+              : `${queue.length} item(s)`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {queue.length > 0 && (
+            <div className="rounded-md border overflow-auto max-h-[500px]">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-background">
+                  <tr className="border-b">
+                    <th className="text-left py-2 px-3 font-medium text-muted-foreground">Photo</th>
+                    <th className="text-left py-2 px-3 font-medium text-muted-foreground">Folder</th>
+                    <th className="text-right py-2 px-3 font-medium text-muted-foreground">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {queue.map((item) => (
+                    <tr key={item.id} className="border-b last:border-0">
+                      <td className="py-2 px-3 truncate max-w-[200px]">{item.photo}</td>
+                      <td className="py-2 px-3 truncate max-w-[160px] text-muted-foreground">
+                        {item.folder}
+                      </td>
+                      <td
+                        className={cn(
+                          'py-2 px-3 text-right font-medium',
+                          STATUS_COLOUR[item.status],
+                        )}
+                      >
+                        {item.status === 'processing' ? (
+                          <span className="flex items-center justify-end gap-1">
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            {STATUS_LABEL[item.status]}
+                          </span>
+                        ) : (
+                          STATUS_LABEL[item.status]
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/ProjectsPage.tsx
+++ b/src/frontend/src/pages/ProjectsPage.tsx
@@ -1,0 +1,200 @@
+/**
+ * src/pages/ProjectsPage.tsx
+ * Project/session selector — lists projects and allows selection (P4-01).
+ * Replaces bid/ui/project_selector.py
+ */
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { FolderOpen, Plus, Trash2, Loader2, CheckCircle2 } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useProjectStore, type Project } from '@/store/projectStore'
+import { projectsApi } from '@/lib/apiClient'
+import { toast } from '@/hooks/useToast'
+import { cn } from '@/lib/utils'
+
+export default function ProjectsPage() {
+  const { projects, selectedProject, setProjects, selectProject, isLoading, setLoading } =
+    useProjectStore()
+  const navigate = useNavigate()
+
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newSource, setNewSource] = useState('')
+  const [newExport, setNewExport] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    projectsApi
+      .list()
+      .then((res) => setProjects(res.data))
+      .catch(() => toast({ title: 'Error', description: 'Failed to load projects', variant: 'destructive' }))
+      .finally(() => setLoading(false))
+  }, [setLoading, setProjects])
+
+  function handleSelect(project: Project) {
+    selectProject(project)
+    toast({ title: `Project selected`, description: project.name })
+    navigate('/')
+  }
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    setCreating(true)
+    try {
+      const res = await projectsApi.create({
+        name: newName,
+        source_folder: newSource,
+        export_folder: newExport,
+      })
+      setProjects([...projects, res.data])
+      setShowCreateForm(false)
+      setNewName('')
+      setNewSource('')
+      setNewExport('')
+      toast({ title: 'Project created', description: res.data.name })
+    } catch {
+      toast({ title: 'Error', description: 'Failed to create project', variant: 'destructive' })
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleDelete(project: Project) {
+    try {
+      await projectsApi.delete(project.id)
+      const updated = projects.filter((p) => p.id !== project.id)
+      setProjects(updated)
+      if (selectedProject?.id === project.id) selectProject(null)
+      toast({ title: 'Project deleted', description: project.name })
+    } catch {
+      toast({ title: 'Error', description: 'Failed to delete project', variant: 'destructive' })
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Projects</h1>
+          <p className="text-muted-foreground">Select or manage your BID projects</p>
+        </div>
+        <Button onClick={() => setShowCreateForm((v) => !v)}>
+          <Plus className="h-4 w-4 mr-2" />
+          New Project
+        </Button>
+      </div>
+
+      {showCreateForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Create Project</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="pname">Project name</Label>
+                <Input
+                  id="pname"
+                  required
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="My Project"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="psource">Source folder path</Label>
+                <Input
+                  id="psource"
+                  required
+                  value={newSource}
+                  onChange={(e) => setNewSource(e.target.value)}
+                  placeholder="/data/source/my-project"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="pexport">Export folder path</Label>
+                <Input
+                  id="pexport"
+                  required
+                  value={newExport}
+                  onChange={(e) => setNewExport(e.target.value)}
+                  placeholder="/data/export/my-project"
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit" disabled={creating}>
+                  {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Create
+                </Button>
+                <Button type="button" variant="outline" onClick={() => setShowCreateForm(false)}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <Card
+              key={project.id}
+              className={cn(
+                'cursor-pointer transition-colors hover:border-primary/60',
+                selectedProject?.id === project.id && 'border-primary ring-1 ring-primary',
+              )}
+            >
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <FolderOpen className="h-5 w-5 shrink-0" />
+                    <CardTitle className="text-base">{project.name}</CardTitle>
+                  </div>
+                  {selectedProject?.id === project.id && (
+                    <CheckCircle2 className="h-5 w-5 text-primary shrink-0" />
+                  )}
+                </div>
+                <CardDescription className="truncate text-xs">
+                  {project.source_folder}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex gap-2">
+                <Button size="sm" onClick={() => handleSelect(project)} className="flex-1">
+                  {selectedProject?.id === project.id ? 'Active' : 'Select'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(project)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+
+          {projects.length === 0 && (
+            <div className="col-span-3 text-center py-12 text-muted-foreground">
+              No projects yet. Create one to get started.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/frontend/src/pages/SettingsPage.tsx
+++ b/src/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,110 @@
+/**
+ * src/pages/SettingsPage.tsx
+ * Settings and preferences panel (P4-04).
+ * Replaces bid/ui/setup_wizard.py
+ */
+import { useState } from 'react'
+import { Moon, Sun, Monitor } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/store/authStore'
+
+type Theme = 'light' | 'dark' | 'system'
+
+export default function SettingsPage() {
+  const { user } = useAuthStore()
+  const [theme, setTheme] = useState<Theme>('system')
+
+  function applyTheme(t: Theme) {
+    setTheme(t)
+    const root = document.documentElement
+    if (t === 'dark') root.classList.add('dark')
+    else if (t === 'light') root.classList.remove('dark')
+    else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      prefersDark ? root.classList.add('dark') : root.classList.remove('dark')
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
+        <p className="text-muted-foreground">Application preferences and account info</p>
+      </div>
+
+      {/* Account */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Account</CardTitle>
+          <CardDescription>Your profile information</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Username</span>
+            <span className="font-medium">{user?.username ?? '—'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Email</span>
+            <span className="font-medium">{user?.email ?? '—'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Role</span>
+            <span className="font-medium">{user?.is_admin ? 'Admin' : 'User'}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Theme — P4-06 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Appearance</CardTitle>
+          <CardDescription>Choose your preferred colour scheme</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2">
+            {([
+              ['light', 'Light', Sun],
+              ['dark', 'Dark', Moon],
+              ['system', 'System', Monitor],
+            ] as const).map(([value, label, Icon]) => (
+              <Button
+                key={value}
+                variant={theme === value ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => applyTheme(value)}
+                className="flex items-center gap-1.5"
+              >
+                <Icon className="h-4 w-4" />
+                {label}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* FileBrowser */}
+      <Card>
+        <CardHeader>
+          <CardTitle>File Management</CardTitle>
+          <CardDescription>
+            Browse, upload, and manage files using the integrated FileBrowser.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline">
+            <a href="/files" target="_blank" rel="noopener noreferrer">
+              Open FileBrowser
+            </a>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/SourcesPage.tsx
+++ b/src/frontend/src/pages/SourcesPage.tsx
@@ -1,0 +1,217 @@
+﻿/**
+ * src/pages/SourcesPage.tsx
+ * Source tree panel — lists source photos for the selected project (P4-04).
+ * Replaces bid/ui/source_tree.py
+ */
+import { useEffect, useState } from 'react'
+import { Loader2, Image, FileImage, ChevronRight, ChevronDown } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useProjectStore } from '@/store/projectStore'
+import { sourcesApi, type SourceTree, type PhotoEntry } from '@/lib/apiClient'
+import { toast } from '@/hooks/useToast'
+import { cn } from '@/lib/utils'
+
+const STATE_COLOUR: Record<string, string> = {
+  new: 'text-blue-500',
+  processing: 'text-yellow-500',
+  ok: 'text-green-500',
+  ok_old: 'text-green-400',
+  error: 'text-red-500',
+  export_fail: 'text-orange-500',
+  skip: 'text-muted-foreground',
+  deleted: 'text-muted-foreground',
+  downloading: 'text-yellow-400',
+}
+
+export default function SourcesPage() {
+  const { selectedProject } = useProjectStore()
+  const [tree, setTree] = useState<SourceTree>({ folders: {} })
+  const [isLoading, setIsLoading] = useState(false)
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set())
+  const [selectedPhoto, setSelectedPhoto] = useState<PhotoEntry | null>(null)
+  const [selectedPhotoName, setSelectedPhotoName] = useState<string>('')
+
+  useEffect(() => {
+    if (!selectedProject) return
+    setIsLoading(true)
+    sourcesApi
+      .getTree(selectedProject.id)
+      .then((res) => {
+        setTree(res.data)
+        const firstFolder = Object.keys(res.data.folders)[0]
+        if (firstFolder) setExpandedFolders(new Set([firstFolder]))
+      })
+      .catch(() =>
+        toast({ title: 'Error', description: 'Failed to load sources', variant: 'destructive' }),
+      )
+      .finally(() => setIsLoading(false))
+  }, [selectedProject])
+
+  if (!selectedProject) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[40vh] gap-2 text-center">
+        <FileImage className="h-12 w-12 text-muted-foreground" />
+        <p className="text-muted-foreground">Select a project to browse sources</p>
+      </div>
+    )
+  }
+
+  const folderNames = Object.keys(tree.folders)
+  const totalPhotos = Object.values(tree.folders).reduce(
+    (sum, folder) => sum + Object.keys(folder).length,
+    0,
+  )
+
+  function toggleFolder(folder: string) {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev)
+      next.has(folder) ? next.delete(folder) : next.add(folder)
+      return next
+    })
+  }
+
+  function selectPhoto(entry: PhotoEntry, filename: string) {
+    setSelectedPhoto(entry)
+    setSelectedPhotoName(filename)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Source Tree</h1>
+        <p className="text-muted-foreground">
+          {totalPhotos} photo{totalPhotos !== 1 ? 's' : ''} in {folderNames.length} folder
+          {folderNames.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Tree panel */}
+        <div className="lg:col-span-2 space-y-1">
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : folderNames.length === 0 ? (
+            <p className="text-muted-foreground text-center py-12">
+              No source photos found.
+            </p>
+          ) : (
+            folderNames.map((folder) => {
+              const items = tree.folders[folder]
+              const expanded = expandedFolders.has(folder)
+              const fileNames = Object.keys(items)
+              return (
+                <div key={folder}>
+                  <button
+                    type="button"
+                    onClick={() => toggleFolder(folder)}
+                    className="flex items-center gap-1.5 w-full text-left px-2 py-1.5 rounded-md hover:bg-accent text-sm font-medium"
+                  >
+                    {expanded ? (
+                      <ChevronDown className="h-4 w-4 shrink-0" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 shrink-0" />
+                    )}
+                    <span className="truncate">{folder}</span>
+                    <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                      {fileNames.length}
+                    </span>
+                  </button>
+                  {expanded && (
+                    <div className="ml-4 space-y-0.5">
+                      {fileNames.map((filename) => {
+                        const photo = items[filename]
+                        return (
+                          <button
+                            type="button"
+                            key={photo.hash_id}
+                            onClick={() => selectPhoto(photo, filename)}
+                            className={cn(
+                              'flex items-center gap-2 w-full text-left px-2 py-1 rounded-md text-sm hover:bg-accent',
+                              selectedPhoto?.hash_id === photo.hash_id && 'bg-accent',
+                            )}
+                          >
+                            <Image className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                            <span className="flex-1 truncate">{filename}</span>
+                            <span
+                              className={cn(
+                                'text-xs shrink-0',
+                                STATE_COLOUR[photo.state] ?? 'text-muted-foreground',
+                              )}
+                            >
+                              {photo.state}
+                            </span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </div>
+
+        {/* Details panel (P4-05 preview) */}
+        <div>
+          {selectedPhoto ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm break-all">{selectedPhotoName}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">State</span>
+                  <span className={cn('font-medium', STATE_COLOUR[selectedPhoto.state])}>
+                    {selectedPhoto.state}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Path</span>
+                  <span className="truncate ml-4 max-w-[160px]">{selectedPhoto.path}</span>
+                </div>
+                {selectedPhoto.size && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Size</span>
+                    <span>{selectedPhoto.size}</span>
+                  </div>
+                )}
+                {selectedPhoto.created && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Created</span>
+                    <span className="text-xs">{selectedPhoto.created}</span>
+                  </div>
+                )}
+                {selectedPhoto.event_name && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Event</span>
+                    <span className="text-xs truncate ml-4">{selectedPhoto.event_name}</span>
+                  </div>
+                )}
+                {selectedPhoto.error_msg && (
+                  <div className="text-xs text-destructive mt-2">{selectedPhoto.error_msg}</div>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground text-sm">
+                Select a photo to view details
+              </CardContent>
+            </Card>
+          )}
+
+          <div className="mt-3">
+            <Button asChild className="w-full" variant="outline">
+              <a href="/files" target="_blank" rel="noopener noreferrer">
+                Open in FileBrowser
+              </a>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/store/authStore.ts
+++ b/src/frontend/src/store/authStore.ts
@@ -1,0 +1,53 @@
+/**
+ * src/store/authStore.ts
+ * Zustand store for authentication state (P3-05).
+ * Persists access/refresh tokens in localStorage.
+ */
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface User {
+  id: number
+  username: string
+  email: string
+  is_admin: boolean
+}
+
+interface AuthState {
+  accessToken: string | null
+  refreshToken: string | null
+  user: User | null
+  setTokens: (access: string, refresh: string) => void
+  setUser: (user: User) => void
+  logout: () => void
+  isAuthenticated: () => boolean
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      refreshToken: null,
+      user: null,
+
+      setTokens: (access, refresh) =>
+        set({ accessToken: access, refreshToken: refresh }),
+
+      setUser: (user) => set({ user }),
+
+      logout: () =>
+        set({ accessToken: null, refreshToken: null, user: null }),
+
+      isAuthenticated: () => get().accessToken !== null,
+    }),
+    {
+      name: 'bid-auth',
+      // Only persist tokens, not derived state
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        user: state.user,
+      }),
+    },
+  ),
+)

--- a/src/frontend/src/store/processingStore.ts
+++ b/src/frontend/src/store/processingStore.ts
@@ -1,0 +1,67 @@
+/**
+ * src/store/processingStore.ts
+ * Zustand store for image processing queue state (P4-03).
+ * Updated via WebSocket messages.
+ */
+import { create } from 'zustand'
+
+export type PhotoStatus = 'new' | 'processing' | 'done' | 'error' | 'skipped'
+
+export interface QueueItem {
+  id: string
+  photo: string
+  folder: string
+  status: PhotoStatus
+  progress?: number
+  error?: string
+  startedAt?: string
+  completedAt?: string
+}
+
+export interface QueueMetrics {
+  queue_length: number
+  active_workers: number
+  max_workers: number
+  completed_total: number
+  failed_total: number
+  utilization_pct: number
+}
+
+interface ProcessingState {
+  queue: QueueItem[]
+  metrics: QueueMetrics | null
+  isProcessing: boolean
+  upsertQueueItem: (item: QueueItem) => void
+  updateQueueItem: (id: string, updates: Partial<QueueItem>) => void
+  setMetrics: (metrics: QueueMetrics) => void
+  setIsProcessing: (active: boolean) => void
+  clearQueue: () => void
+}
+
+export const useProcessingStore = create<ProcessingState>((set) => ({
+  queue: [],
+  metrics: null,
+  isProcessing: false,
+
+  upsertQueueItem: (item) =>
+    set((state) => {
+      const idx = state.queue.findIndex((q) => q.id === item.id)
+      if (idx >= 0) {
+        const updated = [...state.queue]
+        updated[idx] = item
+        return { queue: updated }
+      }
+      return { queue: [...state.queue, item] }
+    }),
+
+  updateQueueItem: (id, updates) =>
+    set((state) => ({
+      queue: state.queue.map((item) =>
+        item.id === id ? { ...item, ...updates } : item,
+      ),
+    })),
+
+  setMetrics: (metrics) => set({ metrics }),
+  setIsProcessing: (isProcessing) => set({ isProcessing }),
+  clearQueue: () => set({ queue: [] }),
+}))

--- a/src/frontend/src/store/projectStore.ts
+++ b/src/frontend/src/store/projectStore.ts
@@ -1,0 +1,36 @@
+/**
+ * src/store/projectStore.ts
+ * Zustand store for project/session state (P3-05, P4-01).
+ */
+import { create } from 'zustand'
+
+export interface Project {
+  id: string
+  name: string
+  source_folder: string
+  export_folder: string
+  created_at: string
+}
+
+interface ProjectState {
+  projects: Project[]
+  selectedProject: Project | null
+  isLoading: boolean
+  error: string | null
+  setProjects: (projects: Project[]) => void
+  selectProject: (project: Project | null) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+}
+
+export const useProjectStore = create<ProjectState>((set) => ({
+  projects: [],
+  selectedProject: null,
+  isLoading: false,
+  error: null,
+
+  setProjects: (projects) => set({ projects }),
+  selectProject: (project) => set({ selectedProject: project }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setError: (error) => set({ error }),
+}))

--- a/src/frontend/tailwind.config.js
+++ b/src/frontend/tailwind.config.js
@@ -1,0 +1,74 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx,js,jsx}',
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/frontend/tsconfig.node.json
+++ b/src/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://api:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
+})


### PR DESCRIPTION
## BID 2.0.0-rc1 — PoC Release

This PR delivers all four implementation phases and the PoC infrastructure as specified in `migration_to_web_plan/implementation_plan.md`.

Closes #6, #7, #8

---

### Deliverable checklist

**Phase 1 — Backend API** (already merged to `main` before branch cut)
- [x] P1-01 OpenAPI 3.0 spec (`/docs`, `/redoc`)
- [x] P1-02 FastAPI image-processing pipeline
- [x] P1-03 Project/session management endpoints
- [x] P1-04 JWT/OAuth2 authentication
- [x] P1-05 SQLite persistence (SQLAlchemy ORM)
- [x] P1-06 API unit tests (≥ 80 % coverage)

**Phase 2 — WebSocket Real-Time Layer** (already merged to `main` before branch cut)
- [x] P2-01 WebSocket server (`src/api/websocket/`)
- [x] P2-02 Event broadcast over WebSocket
- [x] P2-03 Per-file and batch progress streaming
- [x] P2-04 Heartbeat and auto-reconnect
- [x] P2-05 WebSocket integration tests (35 tests)

**Phase 3 — Frontend Shell**
- [x] P3-01 React 18 + TypeScript + Vite scaffold (`src/frontend/`)
- [x] P3-02 React Router v6 client-side routing (`App.tsx`)
- [x] P3-03 Authentication flow: login, token storage, logout, silent refresh
- [x] P3-04 `AppShell`, `Header`, `Sidebar` layout components
- [x] P3-05 Zustand stores (`authStore`, `projectStore`, `processingStore`) + Axios API client
- [x] P3-06 GitHub Actions CI (`.github/workflows/frontend.yml`) — type-check, lint, build

**Phase 4 — Core UI Components**
- [x] P4-01 `ProjectsPage` — list/create/delete/select projects
- [x] P4-02 `ExportsPage` — export profile add/edit/delete/save
- [x] P4-03 `ProcessingPage` — live queue via WebSocket, enqueue-all button
- [x] P4-04 `SourcesPage` — source tree with folder expand/collapse + photo detail panel (P4-05)
- [x] P4-04 `SettingsPage` — account info, FileBrowser link, theme toggle
- [x] P4-05 `useToast` hook + `Toaster` component — 5 s auto-dismiss
- [x] P4-06 Light / dark / system theme via CSS class toggle

**PoC Infrastructure**
- [x] POC-01 `docker-compose.yml` — nginx + api + frontend + filebrowser
- [x] POC-01 `nginx/nginx.conf` — reverse proxy for all services
- [x] POC-01 `src/Dockerfile` — Python 3.11-slim API image
- [x] POC-01 `src/frontend/Dockerfile` — Node 20 multi-stage + nginx frontend image
- [x] POC-01 `.env.example` — documented environment template
- [x] POC-03 `CHANGELOG.md` created
- [x] POC-03 `README.md` — Docker quick-start section added

---

### Backend additions (new in this branch)
- `src/api/routers/sources.py` — `GET /api/v1/projects/{id}/sources` and `GET /api/v1/projects/{id}/sources/{folder}/{photo}` endpoints backed by the existing `SourceService.get_source_tree()`

---

### Test suite

```
380 passed, 16 skipped
```

All pre-existing tests continue to pass. No regressions.

---

### Docker smoke test

```bash
cp .env.example .env
# set SECRET_KEY in .env
docker compose up --build -d
# Open http://localhost/ — login, select project, browse sources, trigger processing
```

---

### Coverage

API layer coverage ≥ 80 % (Phase 1 acceptance criterion satisfied).

---

### Issues

- Closes **#6** — Phase 3: Frontend Shell epic
- Closes **#7** — Phase 4: Core UI Components epic
- Closes **#8** — PoC Release 2.0.0-rc1 epic
